### PR TITLE
Compatibility Update

### DIFF
--- a/allowed-hosts.php
+++ b/allowed-hosts.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WP Allowed Hosts
 Description: Allow WordPress to communicate with other domains.
-Version: 1.0.7
+Version: 1.0.8
 Author: Brandon Groves
 License: GPL3
 */

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: ucfwebcom
 Tags: host, hosts, allow, filter, multisite
 Requires at least: 3.7.0
-Tested up to: 5.2.2
-Stable tag: 1.0.7
+Tested up to: 5.7.0
+Stable tag: 1.0.8
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html
 
@@ -28,6 +28,9 @@ The allowed hosts setting can be enabled at the Network level (multisite) or at 
 The setting is located under WP Admin's Setting > Allow Hosts. If you don't see it you are probably running a Network (multisite) version of wordpress and the plugin is enabled at the network level. Enabling at the Network level will take precedence.
 
 == Changelog ==
+
+= 1.0.8 =
+* Update to readme to reflect compatibility.
 
 = 1.0.7 =
 * Update to readme to reflect compatibility.


### PR DESCRIPTION
Tested against 5.7-RC2 and everything is still working. Some changes have been made in the way safe requests are handled that are slowly making this plugin no longer needed, but it's still a nice tool to have for development use and allows you to whitelist a large number of domains quickly.